### PR TITLE
Rebrand from `ALFI-library` to `ALFI-lib`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # .github
 
-Community health files for the [@ALFI-library](https://github.com/ALFI-library) organization.
+Community health files for the [@ALFI-lib](https://github.com/ALFI-lib) organization.

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,4 +6,4 @@ ALFI (Advanced Library for Function Interpolation) is a library for efficient fu
 
 ## Repositories
 
-You can find the library implementation in the [ALFI-library/ALFI](https://github.com/ALFI-library/ALFI) repository.
+You can find the library implementation in the [ALFI-lib/ALFI](https://github.com/ALFI-lib/ALFI) repository.


### PR DESCRIPTION
### Types of changes
- Rebrand

### Description
Rebrand from `ALFI-library` to `ALFI-lib`.